### PR TITLE
Support new, preferred DOI resolver

### DIFF
--- a/hosts.py
+++ b/hosts.py
@@ -828,7 +828,7 @@ def getDoi(company, journal, entry):
         doi = entry.prism_doi
 
     elif company == 'ACS':
-        doi = entry.id.split("dx.doi.org/")[1]
+        doi = entry.id.split("doi.org/")[1]
 
     elif company == 'Science':
         doi = "10.1126/science." + entry.prism_endingpage[1:]


### PR DESCRIPTION
Hello :-)

Are you certain that your `entry` data _only_ contains the [old DOI resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) URLs? If not, maybe this update helps catch all DOIs that pass through your system.

Cheers!